### PR TITLE
Bump dependencies version to match last minor releases

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,8 +26,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "1.3.x",
-    "angular-sanitize": "1.3.x"
+    "angular": "^1.x",
+    "angular-sanitize": "^1.x"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Bump version of dependencies in order to be able to get last minor versions of angular framework and angular-sanitize.
